### PR TITLE
fix deny(missing_docs) error

### DIFF
--- a/src/database/comparator.rs
+++ b/src/database/comparator.rs
@@ -20,6 +20,7 @@ use core::marker::PhantomData;
 ///   opening databases with a different name
 /// * The comparison implementation
 pub trait Comparator {
+     /// comparator key 
      type K: Key;
 
      /// Return the name of the Comparator


### PR DESCRIPTION
quick comment to fix build failing because of the #![deny(missing_docs)]

am I correct in assuming this will fix the error?


```
/home/leshow/.cargo/registry/src/github.com-1ecc6299db9ec823/leveldb-0.3.9/src/database/comparator.rs:23:11: 23:12 error: missing documentation for an associated type
/home/leshow/.cargo/registry/src/github.com-1ecc6299db9ec823/leveldb-0.3.9/src/database/comparator.rs:23      type K: Key;
                                                                                                                   ^
/home/leshow/.cargo/registry/src/github.com-1ecc6299db9ec823/leveldb-0.3.9/src/lib.rs:43:9: 43:21 note: lint level defined here
/home/leshow/.cargo/registry/src/github.com-1ecc6299db9ec823/leveldb-0.3.9/src/lib.rs:43 #![deny(missing_docs)]
```