### PR TITLE
Mark Error::new_from_i8() as unsafe.

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -17,14 +17,15 @@ impl Error {
     }
 
     /// create an error from a c-string buffer.
-    pub fn new_from_i8(message: *const i8) -> Error {
+    ///
+    /// This method is `unsafe` because the pointer must be valid and point to heap.
+    /// The pointer will be passed to `free`!
+    pub unsafe fn new_from_i8(message: *const i8) -> Error {
         use std::str::from_utf8;
         use std::ffi::CStr;
 
-        let err_string = unsafe {
-            from_utf8(CStr::from_ptr(message).to_bytes()).unwrap().to_string()
-        };
-        unsafe { free(message as *mut c_void) };
+        let err_string = from_utf8(CStr::from_ptr(message).to_bytes()).unwrap().to_string();
+        free(message as *mut c_void);
         Error::new(err_string)
     }
 }

--- a/src/database/management.rs
+++ b/src/database/management.rs
@@ -16,12 +16,12 @@ pub fn destroy(name: &Path, options: Options) -> Result<(), Error> {
         leveldb_destroy_db(c_options,
                            c_string.as_bytes_with_nul().as_ptr() as *const i8,
                            &mut error);
-    };
 
-    if error == ptr::null_mut() {
-        Ok(())
-    } else {
-        Err(Error::new_from_i8(error))
+        if error == ptr::null_mut() {
+            Ok(())
+        } else {
+            Err(Error::new_from_i8(error))
+        }
     }
 }
 
@@ -34,11 +34,11 @@ pub fn repair(name: &Path, options: Options) -> Result<(), Error> {
         leveldb_repair_db(c_options,
                           c_string.as_bytes_with_nul().as_ptr() as *const i8,
                           &mut error);
-    };
 
-    if error == ptr::null_mut() {
-        Ok(())
-    } else {
-        Err(Error::new_from_i8(error))
+        if error == ptr::null_mut() {
+            Ok(())
+        } else {
+            Err(Error::new_from_i8(error))
+        }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -105,20 +105,19 @@ impl<K: Key> Database<K> {
     /// The database will be created using the settings given in `options`.
     pub fn open(name: &Path, options: Options) -> Result<Database<K>, Error> {
         let mut error = ptr::null_mut();
-        let res = unsafe {
+        unsafe {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, None);
             let db = leveldb_open(c_options as *const leveldb_options_t,
                                   c_string.as_bytes_with_nul().as_ptr() as *const i8,
                                   &mut error);
             leveldb_options_destroy(c_options);
-            db
-        };
 
-        if error == ptr::null_mut() {
-            Ok(Database::new(res, options, None))
-        } else {
-            Err(Error::new_from_i8(error))
+            if error == ptr::null_mut() {
+                Ok(Database::new(db, options, None))
+            } else {
+                Err(Error::new_from_i8(error))
+            }
         }
     }
 
@@ -136,20 +135,19 @@ impl<K: Key> Database<K> {
                                                       -> Result<Database<K>, Error> {
         let mut error = ptr::null_mut();
         let comp_ptr = create_comparator(Box::new(comparator));
-        let res = unsafe {
+        unsafe {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, Some(comp_ptr));
             let db = leveldb_open(c_options as *const leveldb_options_t,
                                   c_string.as_bytes_with_nul().as_ptr() as *const i8,
                                   &mut error);
             leveldb_options_destroy(c_options);
-            db
-        };
 
-        if error == ptr::null_mut() {
-            Ok(Database::new(res, options, Some(comp_ptr)))
-        } else {
-            Err(Error::new_from_i8(error))
+            if error == ptr::null_mut() {
+                Ok(Database::new(db, options, Some(comp_ptr)))
+            } else {
+                Err(Error::new_from_i8(error))
+            }
         }
     }
 }


### PR DESCRIPTION
The method dereferences arbitrary pointer given to it as an argument.
That enables the user to violate Rust safety guarantees using only safe
code. This commit fixes the function signature to warn users of
potential dangers.

Example "safe" code that seg faults:

```rust
let err = Error::new_from_i8(42 as *const i8);
```