### PR TITLE
Change `free` to `leveldb_free`.

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -1,6 +1,7 @@
 //! The module defining custom leveldb error type.
 
-use libc::{c_void, free};
+use libc::c_void;
+use leveldb_sys::leveldb_free;
 use std;
 
 /// A leveldb error, just containing the error string
@@ -25,7 +26,7 @@ impl Error {
         use std::ffi::CStr;
 
         let err_string = from_utf8(CStr::from_ptr(message).to_bytes()).unwrap().to_string();
-        free(message as *mut c_void);
+        leveldb_free(message as *mut c_void);
         Error::new(err_string)
     }
 }


### PR DESCRIPTION
According to the [documentation](https://github.com/google/leveldb/blob/47cb9e2a211e1d7157078ba7bab536beb29e56dc/include/leveldb/c.h#L29), one must call `leveldb_free` instead of `free` on Windows. So this
commit changes `free` to `leveldb_free` in string deallocation code in
order to fix it.