### PR TITLE
update Readme example to include Iterable import

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ extern crate leveldb;
 
 use tempdir::TempDir;
 use leveldb::database::Database;
+use leveldb::iterator::Iterable;
 use leveldb::kv::KV;
 use leveldb::options::{Options,WriteOptions,ReadOptions};
 


### PR DESCRIPTION
Example provided in Readme is not working due to missing Iterator path binding. Add required use declaration to example.