### PR TITLE
Make crate work ok aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "leveldb"
-version = "0.8.4"
+version = "0.8.5"
 authors = [ "Florian Gilcher <florian.gilcher@asquera.de>" ]
 
 description = "An interface for leveldb"

--- a/src/database/batch.rs
+++ b/src/database/batch.rs
@@ -124,9 +124,9 @@ pub trait WritebatchIterator {
 }
 
 extern "C" fn put_callback<K: Key, T: WritebatchIterator<K = K>>(state: *mut c_void,
-                                                                 key: *const libc::c_char,
+                                                                 key: *const c_char,
                                                                  keylen: size_t,
-                                                                 val: *const libc::c_char,
+                                                                 val: *const c_char,
                                                                  vallen: size_t) {
     unsafe {
         let iter: &mut T = &mut *(state as *mut T);
@@ -138,7 +138,7 @@ extern "C" fn put_callback<K: Key, T: WritebatchIterator<K = K>>(state: *mut c_v
 }
 
 extern "C" fn deleted_callback<K: Key, T: WritebatchIterator<K = K>>(state: *mut c_void,
-                                                                     key: *const libc::c_char,
+                                                                     key: *const c_char,
                                                                      keylen: size_t) {
     unsafe {
         let iter: &mut T = &mut *(state as *mut T);

--- a/src/database/batch.rs
+++ b/src/database/batch.rs
@@ -124,25 +124,25 @@ pub trait WritebatchIterator {
 }
 
 extern "C" fn put_callback<K: Key, T: WritebatchIterator<K = K>>(state: *mut c_void,
-                                                                 key: *const i8,
+                                                                 key: *const libc::c_char,
                                                                  keylen: size_t,
-                                                                 val: *const i8,
+                                                                 val: *const libc::c_char,
                                                                  vallen: size_t) {
     unsafe {
         let iter: &mut T = &mut *(state as *mut T);
-        let key_slice = slice::from_raw_parts::<u8>(key as *const u8, keylen as usize);
-        let val_slice = slice::from_raw_parts::<u8>(val as *const u8, vallen as usize);
+        let key_slice = slice::from_raw_parts::<u8>(key as *const _, keylen as usize);
+        let val_slice = slice::from_raw_parts::<u8>(val as *const _, vallen as usize);
         let k = from_u8::<<T as WritebatchIterator>::K>(key_slice);
         iter.put(k, val_slice);
     }
 }
 
 extern "C" fn deleted_callback<K: Key, T: WritebatchIterator<K = K>>(state: *mut c_void,
-                                                                     key: *const i8,
+                                                                     key: *const libc::c_char,
                                                                      keylen: size_t) {
     unsafe {
         let iter: &mut T = &mut *(state as *mut T);
-        let key_slice = slice::from_raw_parts::<u8>(key as *const u8, keylen as usize);
+        let key_slice = slice::from_raw_parts::<u8>(key as *const _, keylen as usize);
         let k = from_u8::<<T as WritebatchIterator>::K>(key_slice);
         iter.deleted(k);
     }

--- a/src/database/comparator.rs
+++ b/src/database/comparator.rs
@@ -59,9 +59,9 @@ unsafe trait InternalComparator : Comparator where Self: Sized {
     }
 
     extern "C" fn compare(state: *mut c_void,
-                          a: *const libc::c_char,
+                          a: *const c_char,
                           a_len: size_t,
-                          b: *const libc::c_char,
+                          b: *const c_char,
                           b_len: size_t)
                           -> i32 {
         unsafe {

--- a/src/database/comparator.rs
+++ b/src/database/comparator.rs
@@ -59,14 +59,14 @@ unsafe trait InternalComparator : Comparator where Self: Sized {
     }
 
     extern "C" fn compare(state: *mut c_void,
-                          a: *const i8,
+                          a: *const libc::c_char,
                           a_len: size_t,
-                          b: *const i8,
+                          b: *const libc::c_char,
                           b_len: size_t)
                           -> i32 {
         unsafe {
-            let a_slice = slice::from_raw_parts::<u8>(a as *const u8, a_len as usize);
-            let b_slice = slice::from_raw_parts::<u8>(b as *const u8, b_len as usize);
+            let a_slice = slice::from_raw_parts::<u8>(a as *const _, a_len as usize);
+            let b_slice = slice::from_raw_parts::<u8>(b as *const _, b_len as usize);
             let x = &*(state as *mut Self);
             let a_key = from_u8::<<Self as Comparator>::K>(a_slice);
             let b_key = from_u8::<<Self as Comparator>::K>(b_slice);

--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -1,6 +1,6 @@
 //! The module defining custom leveldb error type.
 
-use libc::c_void;
+use libc::{c_void, c_char};
 use leveldb_sys::leveldb_free;
 use std;
 
@@ -21,7 +21,7 @@ impl Error {
     ///
     /// This method is `unsafe` because the pointer must be valid and point to heap.
     /// The pointer will be passed to `free`!
-    pub unsafe fn new_from_i8(message: *const libc::c_char) -> Error {
+    pub unsafe fn new_from_i8(message: *const c_char) -> Error {
         use std::str::from_utf8;
         use std::ffi::CStr;
 

--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -21,7 +21,7 @@ impl Error {
     ///
     /// This method is `unsafe` because the pointer must be valid and point to heap.
     /// The pointer will be passed to `free`!
-    pub unsafe fn new_from_i8(message: *const i8) -> Error {
+    pub unsafe fn new_from_i8(message: *const libc::c_char) -> Error {
         use std::str::from_utf8;
         use std::ffi::CStr;
 

--- a/src/database/management.rs
+++ b/src/database/management.rs
@@ -5,6 +5,7 @@ use std::ffi::CString;
 use std::ptr;
 use std::path::Path;
 
+use libc::c_char;
 use leveldb_sys::{leveldb_destroy_db, leveldb_repair_db};
 
 /// destroy a database. You shouldn't hold a handle on the database anywhere at that time.
@@ -14,7 +15,7 @@ pub fn destroy(name: &Path, options: Options) -> Result<(), Error> {
         let c_string = CString::new(name.to_str().unwrap()).unwrap();
         let c_options = c_options(&options, None);
         leveldb_destroy_db(c_options,
-                           c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
+                           c_string.as_bytes_with_nul().as_ptr() as *const c_char,
                            &mut error);
 
         if error == ptr::null_mut() {
@@ -32,7 +33,7 @@ pub fn repair(name: &Path, options: Options) -> Result<(), Error> {
         let c_string = CString::new(name.to_str().unwrap()).unwrap();
         let c_options = c_options(&options, None);
         leveldb_repair_db(c_options,
-                          c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
+                          c_string.as_bytes_with_nul().as_ptr() as *const c_char,
                           &mut error);
 
         if error == ptr::null_mut() {

--- a/src/database/management.rs
+++ b/src/database/management.rs
@@ -14,7 +14,7 @@ pub fn destroy(name: &Path, options: Options) -> Result<(), Error> {
         let c_string = CString::new(name.to_str().unwrap()).unwrap();
         let c_options = c_options(&options, None);
         leveldb_destroy_db(c_options,
-                           c_string.as_bytes_with_nul().as_ptr() as *const i8,
+                           c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
                            &mut error);
 
         if error == ptr::null_mut() {
@@ -32,7 +32,7 @@ pub fn repair(name: &Path, options: Options) -> Result<(), Error> {
         let c_string = CString::new(name.to_str().unwrap()).unwrap();
         let c_options = c_options(&options, None);
         leveldb_repair_db(c_options,
-                          c_string.as_bytes_with_nul().as_ptr() as *const i8,
+                          c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
                           &mut error);
 
         if error == ptr::null_mut() {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -16,6 +16,8 @@ use self::key::Key;
 
 use std::marker::PhantomData;
 
+use libc::c_char;
+
 pub mod options;
 pub mod error;
 pub mod iterator;
@@ -110,7 +112,7 @@ impl<K: Key> Database<K> {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, None);
             let db = leveldb_open(c_options as *const leveldb_options_t,
-                                  c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
+                                  c_string.as_bytes_with_nul().as_ptr() as *const c_char,
                                   &mut error);
             leveldb_options_destroy(c_options);
 
@@ -140,7 +142,7 @@ impl<K: Key> Database<K> {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, Some(comp_ptr));
             let db = leveldb_open(c_options as *const leveldb_options_t,
-                                  c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
+                                  c_string.as_bytes_with_nul().as_ptr() as *const c_char,
                                   &mut error);
             leveldb_options_destroy(c_options);
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -110,7 +110,7 @@ impl<K: Key> Database<K> {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, None);
             let db = leveldb_open(c_options as *const leveldb_options_t,
-                                  c_string.as_bytes_with_nul().as_ptr() as *const i8,
+                                  c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
                                   &mut error);
             leveldb_options_destroy(c_options);
 
@@ -140,7 +140,7 @@ impl<K: Key> Database<K> {
             let c_string = CString::new(name.to_str().unwrap()).unwrap();
             let c_options = c_options(&options, Some(comp_ptr));
             let db = leveldb_open(c_options as *const leveldb_options_t,
-                                  c_string.as_bytes_with_nul().as_ptr() as *const i8,
+                                  c_string.as_bytes_with_nul().as_ptr() as *const libc::c_char,
                                   &mut error);
             leveldb_options_destroy(c_options);
 


### PR DESCRIPTION
Both `cargo build` was failing with 16 errors. All of the type `expected i8, found u8`.

I made it work on aarch64 and x64 following:
- https://github.com/sfackler/rust-openssl/commit/f54af75eb7f8c861383119722f548cb2866ca813
- https://github.com/rust-lang/rust/issues/60226

Im not a pro on this topic, but I hope that this fix is correct :)