### PR TITLE
Support not forcing a snappy build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/skade/leveldb"
 
 autotests = false
 
+[features]
+default = ["leveldb-sys/snappy"]
+
 [lib]
 
 name = "leveldb"
@@ -26,7 +29,6 @@ libc = "0.2.4"
 
 [dependencies.leveldb-sys]
 version = "2.0.0"
-features = ["snappy"]
 
 [dev-dependencies]
 tempdir = "0.3.4"


### PR DESCRIPTION
This lets us use the system snappy if it's available. Particularly handy for aarch64 cross compiles since we don't pass `--host` to the snappy build.