### PR TITLE
Add Github Actions.

### DIFF
--- a/.github/workflows/suite.yml
+++ b/.github/workflows/suite.yml
@@ -1,0 +1,46 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  test-x86_64-unknown-linux-gnu:
+    name: Test Suite (x86_64-unknown-linux-gnu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test-x86_64-unknown-windows-msvc:
+    name: Test Suite (x86_64-unknown-windows-msvc)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  test-x86_64-unknown-darwin:
+    name: Test Suite (x86_64-unknown-darwin)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-rust:
-  - 1.31.0
-  - 1.43.1
-  - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
-sudo: false


### PR DESCRIPTION
Adds automated CI for OS which GA officially supports. No fmt/clippy since they didn't pass.

Windows is fixed in https://github.com/skade/leveldb-sys/pull/18.

Example results: https://github.com/timberio/leveldb/runs/1098011055?check_suite_focus=true