### PR TITLE
Do not panic when failed to decode levelDB CStr Err Message

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -26,7 +26,7 @@ impl Error {
         use std::str::from_utf8;
         use std::ffi::CStr;
 
-        let err_string = from_utf8(CStr::from_ptr(message).to_bytes()).unwrap().to_string();
+        let err_string = from_utf8(CStr::from_ptr(message).to_bytes()).unwrap_or("Unknown Error").to_string();
         leveldb_free(message as *mut c_void);
         Error::new(err_string)
     }


### PR DESCRIPTION
My program panicked when levelDB error message fails to be decoded, which is unnecessary.

Quote from another issue:
```
I get following error during initialization (Python 3.8.11).

import bitcoin_explorer as bex
db = bex.BitcoinDB(r"D:\BTC\Chain")

[19:02:59] INFO - Start loading block_index
[19:03:00] INFO - Longest chain: 702696
thread '' panicked at 'called Result::unwrap() on an Err value: Utf8Error { valid_up_to: 58, error_len: Some(1) }', C:\Users\runneradmin.cargo\registry\src\github.com-1ecc6299db9ec823\leveldb-0.8.6\src\database\error.rs:29:72
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
Traceback (most recent call last):
File "C:/Users/T/PycharmProjects/BTC_explorer/main.py", line 3, in 
db = bex.BitcoinDB(r"D:\BTC\Chain")
File "D:\anaconda3\envs\env_btc\lib\site-packages\bitcoin_explorer_init_.py", line 82, in init
self.db = _BitcoinDB(str(path), tx_index)
pyo3_runtime.PanicException: called Result::unwrap() on an Err value: Utf8Error { valid_up_to: 58, error_len: Some(1) }
Process finished with exit code 1

I have data downloaded using Bitcoin Core in D:\BTC\Chain\blocks (.dat files) and D:\BTC\Chain\blocks\index (.ldb files).
```