### PR TITLE
Expose `Key` trait as public to allow custom data types as leveldb keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ name = "leveldb"
 
 [dependencies]
 
-db-key = "0.0.5"
 libc = "0.2.4"
 
 [dependencies.leveldb-sys]

--- a/src/database/key.rs
+++ b/src/database/key.rs
@@ -1,0 +1,25 @@
+pub trait Key {
+    fn from_u8(key: &[u8]) -> Self;
+    fn as_slice<T, F: Fn(&[u8]) -> T>(&self, f: F) -> T;
+}
+
+pub fn from_u8<K: Key>(key: &[u8]) -> K {
+    Key::from_u8(key)
+}
+
+impl Key for i32 {
+    fn from_u8(key: &[u8]) -> i32 {
+        assert!(key.len() == 4);
+
+        (key[0] as i32) << 24 | (key[1] as i32) << 16 | (key[2] as i32) << 8 | (key[3] as i32)
+    }
+
+    fn as_slice<T, F: Fn(&[u8]) -> T>(&self, f: F) -> T {
+        let mut dst = [0u8, 0, 0, 0];
+        dst[0] = (*self >> 24) as u8;
+        dst[1] = (*self >> 16) as u8;
+        dst[2] = (*self >> 8) as u8;
+        dst[3] = *self as u8;
+        f(&dst)
+    }
+}

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,7 +1,5 @@
 //! The main database module, allowing to interface with leveldb on
 //! a key-value basis.
-extern crate db_key as key;
-
 use leveldb_sys::*;
 
 use self::options::{Options, c_options};
@@ -28,6 +26,7 @@ pub mod batch;
 pub mod management;
 pub mod compaction;
 pub mod bytes;
+pub mod key;
 
 #[allow(missing_docs)]
 struct RawDB {

--- a/tests/comparator.rs
+++ b/tests/comparator.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod comparator {
   use libc::c_char;
-  use key::Key;
+  use leveldb::database::key::Key;
   use utils::{tmpdir, db_put_simple};
   use leveldb::database::{Database};
   use leveldb::iterator::Iterable;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,4 +1,3 @@
-extern crate db_key as key;
 extern crate leveldb;
 extern crate tempdir;
 extern crate libc;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,9 +1,10 @@
 use leveldb::database::Database;
 use leveldb::database::kv::{KV};
+use leveldb::database::key::Key;
 use leveldb::options::{Options,WriteOptions};
 use std::path::Path;
 use tempdir::TempDir;
-use key::Key;
+
 
 pub fn open_database<K: Key + Ord>(path: &Path, create_if_missing: bool) -> Database<K> {
   let mut opts = Options::new();


### PR DESCRIPTION
Currently there is no way to use our own data types as keys because the module is private, for example this will not work

```rs
// ...
use leveldb::database::key::Key; // error[E0603]: crate `key` is private

#[derive(Clone)]
struct MyData {
    key: String,
}

impl Key for MyData {
    fn from_u8(key: &[u8]) -> Self {
        MyData {
            key: str::from_utf8(key).unwrap().into(),
        }
    }

    fn as_slice<T, F: Fn(&[u8]) -> T>(&self, f: F) -> T {
        let dst = self.key.as_bytes();
        f(&dst)
    }
}
// ...
```

This PR creates a simple fix by removing the `db-key` dependency and adds the `Key` trait as public in `src/database/key.rs`.

A full example is [here](https://github.com/cassc/play-leveldb)