### PR TITLE
Verify that concurrent write wrote correctly

### DIFF
--- a/src/database/error.rs
+++ b/src/database/error.rs
@@ -42,7 +42,7 @@ impl std::error::Error for Error {
     fn description(&self) -> &str {
         &self.message
     }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         None
     }
 }

--- a/src/database/iterator.rs
+++ b/src/database/iterator.rs
@@ -110,13 +110,10 @@ impl<'a, K: Key + 'a> Iterable<'a, K> for Database<K> {
 pub trait LevelDBIterator<'a, K: Key> {
     type RevIter: LevelDBIterator<'a, K>;
 
-    #[inline]
     fn raw_iterator(&self) -> *mut leveldb_iterator_t;
 
-    #[inline]
     fn start(&self) -> bool;
 
-    #[inline]
     fn started(&mut self);
 
     fn reverse(self) -> Self::RevIter;

--- a/tests/concurrent_access.rs
+++ b/tests/concurrent_access.rs
@@ -1,6 +1,6 @@
-use utils::{tmpdir,open_database};
-use leveldb::options::{Options,WriteOptions};
 use leveldb::database::kv::KV;
+use leveldb::options::{Options, ReadOptions, WriteOptions};
+use utils::{open_database, tmpdir};
 
 #[test]
 fn access_from_threads() {
@@ -14,17 +14,27 @@ fn access_from_threads() {
     let database = open_database(tmp.path(), true);
     let shared = Arc::new(database);
 
-    (0..10).map(|i| {
-         let local_db = shared.clone();
+    (0..10)
+        .map(|i| {
+            let local_db = shared.clone();
 
-         thread::spawn(move || {
-             let write_opts = WriteOptions::new();
-             match local_db.put(write_opts, i, &[i as u8]) {
-                 Ok(_) => { },
-                 Err(e) => { panic!("failed to write to database: {:?}", e) }
-             }
-         })
-    })
-    .map(JoinHandle::join)
-    .collect::<Vec<_>>();
+            thread::spawn(move || {
+                let write_opts = WriteOptions::new();
+                match local_db.put(write_opts, i, &[i as u8]) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        panic!("failed to write to database: {:?}", e)
+                    }
+                }
+            })
+        })
+        .map(JoinHandle::join)
+        .for_each(drop);
+
+    for i in 0..10 {
+        assert_eq!(
+            shared.get(ReadOptions::new(), i).unwrap(),
+            Some(vec![i as u8])
+        );
+    }
 }

--- a/tests/iterator.rs
+++ b/tests/iterator.rs
@@ -81,7 +81,7 @@ fn test_key_iterator() {
   db_put_simple(database, 1, &[1]);
   db_put_simple(database, 2, &[2]);
 
-  let iterable: &mut Iterable<i32> = database;
+  let iterable: &mut dyn Iterable<i32> = database;
 
   let read_opts = ReadOptions::new();
   let mut iter = iterable.keys_iter(read_opts);
@@ -96,7 +96,7 @@ fn test_value_iterator() {
   db_put_simple(database, 1, &[1]);
   db_put_simple(database, 2, &[2]);
 
-  let iterable: &mut Iterable<i32> = database;
+  let iterable: &mut dyn Iterable<i32> = database;
 
   let read_opts = ReadOptions::new();
   let mut iter = iterable.value_iter(read_opts);


### PR DESCRIPTION
# Summary
Test `tests/concurrent_access.rs` spins up 10 threads, each writing to
their own key concurrently. However, there is no verificiation that the
values were actually written.

#Solution
This commit waits for the threads to join and then verifies all 10
values.

#Byproducts:
There were some warnings (mostly missing `dyn`s and #[inline]s in
function prototypes) which this commit also fixes.